### PR TITLE
net-misc/turbovnc: fixes

### DIFF
--- a/net-misc/turbovnc/turbovnc-2.2.5-r2.ebuild
+++ b/net-misc/turbovnc/turbovnc-2.2.5-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 inherit cmake
 
-DESCRIPTION="A fast replacement for tigetvnc"
+DESCRIPTION="A fast replacement for TigerVNC"
 HOMEPAGE="https://www.turbovnc.org/"
 SRC_URI="https://sourceforge.net/projects/turbovnc/files/${PV}/${P}.tar.gz/download -> ${P}.tar.gz"
 RESTRICT="primaryuri"
@@ -17,12 +17,15 @@ IUSE=""
 DEPEND="virtual/jdk:1.8
 	>=media-libs/libjpeg-turbo-2.0.0[java]
 	!net-misc/tigervnc"
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	x11-apps/xkbcomp"
 
 src_configure() {
 	local mycmakeargs=(
 		-DTJPEG_JAR=/usr/share/java/turbojpeg.jar
 		-DTJPEG_JNILIBRARY=/usr/lib64/libturbojpeg.so
+		-DXKB_BIN_DIRECTORY=/usr/bin
+		-DXKB_DFLT_RULES=base
 	)
 	cmake_src_configure
 }
@@ -30,4 +33,5 @@ src_configure() {
 src_install() {
 	cmake_src_install
 	find "${D}/usr/share/man/man1/" -name Xserver.1\* -print0 | xargs -0 rm
+	einstalldocs
 }


### PR DESCRIPTION
I was unable to use this as it was, especially with simple arguments (`vncserver :1`). [See thread if interested](https://groups.google.com/g/turbovnc-users/c/42GLfRY5m6g).

* Fix description
* Add `x11-apps/xkbcomp` dep
* Set default xkb rules file to `base`
* Set XKB_BIN_DIRECTORY to `/usr/bin` (where `xkbcomp` is)
* Add `einstalldocs`

You should consider sending a PR to https://github.com/gentoo/gentoo since they already have VirtualGL in the tree.